### PR TITLE
floko: Replace string in reset_settings_message.

### DIFF
--- a/res/values-be-rBY/cr_strings.xml
+++ b/res/values-be-rBY/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Не сканаваць медыя</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Скінуць налады</string>
-    <string name="reset_settings_message">Гэта прывядзе да скіду большасці налад crdroid да значэнняў па змаўчанні для бягучага карыстальніка. Працягнуць?</string>
+    <string name="reset_settings_message">Гэта прывядзе да скіду большасці налад FlokoROM да значэнняў па змаўчанні для бягучага карыстальніка. Працягнуць?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Абнаўленні</string>
     <string name="ota_crdroid_summary">Праверыць OTA абнаўленне і спасылкі для вашай прылады</string>

--- a/res/values-bg-rBG/cr_strings.xml
+++ b/res/values-bg-rBG/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Не се сканирай медия</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Нулирай настройките</string>
-    <string name="reset_settings_message">Това ще възстанови повечето crdroid настройки до техните стойности по подразбиране за текущия потребител. Искате ли да продължите?</string>
+    <string name="reset_settings_message">Това ще възстанови повечето FlokoROM настройки до техните стойности по подразбиране за текущия потребител. Искате ли да продължите?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Актуализации</string>
     <string name="ota_crdroid_summary">Проверете за актуализация на ОТА и връзки за вашето устройство</string>

--- a/res/values-cs-rCZ/cr_strings.xml
+++ b/res/values-cs-rCZ/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Neskenovat média</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Obnovit nastavení</string>
-    <string name="reset_settings_message">Tímto obnovíte většinu nastavení crDroidu pro aktuálního uživatele na výchozí hodnoty. Přejete si pokračovat?</string>
+    <string name="reset_settings_message">Tímto obnovíte většinu nastavení FlokoROM pro aktuálního uživatele na výchozí hodnoty. Přejete si pokračovat?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Aktualizace</string>
     <string name="ota_crdroid_summary">Zkontrolovat aktualizaci OTA a odkazy pro zařízení</string>

--- a/res/values-da-rDK/cr_strings.xml
+++ b/res/values-da-rDK/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Skan ikke medier</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Nulstil indstillinger</string>
-    <string name="reset_settings_message">Dette vil nulstille de fleste crDroid-indstillinger til deres standardværdier for den aktuelle bruger. Fortsæt?</string>
+    <string name="reset_settings_message">Dette vil nulstille de fleste FlokoROM-indstillinger til deres standardværdier for den aktuelle bruger. Fortsæt?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Opdateringer</string>
     <string name="ota_crdroid_summary">Se efter OTA-opdatering og links til enheden</string>

--- a/res/values-de-rDE/cr_strings.xml
+++ b/res/values-de-rDE/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Nicht nach Mediendateien suchen</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Einstellungen zurücksetzen</string>
-    <string name="reset_settings_message">Dadurch werden die meisten Crdroid Einstellungen auf ihre Standardwerte für den aktuellen Benutzer zurückgesetzt. Möchten Sie fortfahren?</string>
+    <string name="reset_settings_message">Dadurch werden die meisten FlokoROM Einstellungen auf ihre Standardwerte für den aktuellen Benutzer zurückgesetzt. Möchten Sie fortfahren?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Nach OTA-Update und Links für Ihr Gerät suchen</string>

--- a/res/values-es-rES/cr_strings.xml
+++ b/res/values-es-rES/cr_strings.xml
@@ -1555,7 +1555,7 @@ https://plus.google.com/u/0/communities/118297646046960923906</string>
     <string name="media_scanner_on_boot_disabled">No escanear medios</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reestablecer la configuración predeterminada</string>
-    <string name="reset_settings_message">Esto restablecerá la mayoría de la configuración de crDroid a sus valores predeterminados para el usuario actual. ¿Deseas continuar?</string>
+    <string name="reset_settings_message">Esto restablecerá la mayoría de la configuración de FlokoROM a sus valores predeterminados para el usuario actual. ¿Deseas continuar?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Actualizaciones</string>
     <string name="ota_crdroid_summary">Comprueba si hay actualizaciones OTA y enlaces para tu dispositivo</string>

--- a/res/values-es-rVE/cr_strings.xml
+++ b/res/values-es-rVE/cr_strings.xml
@@ -1555,7 +1555,7 @@ puede instalar nuevos paquetes de iconos desde la play store buscando \"Chronus 
     <string name="media_scanner_on_boot_disabled">No escanear multimedia</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reestablecer la configuración predeterminada</string>
-    <string name="reset_settings_message">Esto restablecerá la mayoría de la configuración de crDroid a sus valores predeterminados para el usuario actual. ¿Deseas continuar?</string>
+    <string name="reset_settings_message">Esto restablecerá la mayoría de la configuración de FlokoROM a sus valores predeterminados para el usuario actual. ¿Deseas continuar?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Actualizacaciones</string>
     <string name="ota_crdroid_summary">Comprobar si hay actualizaciones OTA para el equipo</string>

--- a/res/values-et-rEE/cr_strings.xml
+++ b/res/values-et-rEE/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Check for OTA update and links for your device</string>

--- a/res/values-fa-rIR/cr_strings.xml
+++ b/res/values-fa-rIR/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Check for OTA update and links for your device</string>

--- a/res/values-fr-rFR/cr_strings.xml
+++ b/res/values-fr-rFR/cr_strings.xml
@@ -1555,7 +1555,7 @@ https://plus.google.com/communities/118297646046960923906</string>
     <string name="media_scanner_on_boot_disabled">Ne pas analyser les médias</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Réinitialiser les paramètres</string>
-    <string name="reset_settings_message">Cela réinitialisera la plupart des paramètres crdroid à leurs valeurs par défaut pour l’utilisateur actuel. Souhaitez-vous continuer ?</string>
+    <string name="reset_settings_message">Cela réinitialisera la plupart des paramètres FlokoROM à leurs valeurs par défaut pour l’utilisateur actuel. Souhaitez-vous continuer ?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Mises à jour</string>
     <string name="ota_crdroid_summary">Vérifier la mise à jour OTA et liens pour votre appareil</string>

--- a/res/values-hi-rIN/cr_strings.xml
+++ b/res/values-hi-rIN/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Check for OTA update and links for your device</string>

--- a/res/values-hr-rHR/cr_strings.xml
+++ b/res/values-hr-rHR/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Check for OTA update and links for your device</string>

--- a/res/values-hu-rHU/cr_strings.xml
+++ b/res/values-hu-rHU/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Ne legyen médiakeresés</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Beállítások visszaállítása</string>
-    <string name="reset_settings_message">Ez a legtöbb crDroid-beállítás értékét visszaállítja alapértelmezettre a jelenlegi felhasználónál. Szeretné folytatni?</string>
+    <string name="reset_settings_message">Ez a legtöbb FlokoROM-beállítás értékét visszaállítja alapértelmezettre a jelenlegi felhasználónál. Szeretné folytatni?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Frissítések</string>
     <string name="ota_crdroid_summary">OTA frissítés ellenőrzése</string>

--- a/res/values-in-rID/cr_strings.xml
+++ b/res/values-in-rID/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Jangan pindai media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Kembalikan pengaturan</string>
-    <string name="reset_settings_message">Ini akan mengembalikan kebanyakan pengaturan crdroid ke nilai bawaannya untuk pengguna saat ini. Apakah anda yakin untuk melanjutkan?</string>
+    <string name="reset_settings_message">Ini akan mengembalikan kebanyakan pengaturan FlokoROM ke nilai bawaannya untuk pengguna saat ini. Apakah anda yakin untuk melanjutkan?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Pembaruan</string>
     <string name="ota_crdroid_summary">Cek untuk pembaruan OTA dan hubungkan ke perangkat anda</string>

--- a/res/values-it-rIT/cr_strings.xml
+++ b/res/values-it-rIT/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Non eseguire la scansione multimediale</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Ripristina le impostazioni</string>
-    <string name="reset_settings_message">Questo ripristinerà la maggior parte delle impostazioni crdroid ai loro valori predefiniti per l\'utente corrente. Vuoi continuare?</string>
+    <string name="reset_settings_message">Questo ripristinerà la maggior parte delle impostazioni FlokoROM ai loro valori predefiniti per l\'utente corrente. Vuoi continuare?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Aggiornamenti</string>
     <string name="ota_crdroid_summary">Controlla l\'aggiornamento OTA e i link per il tuo dispositivo</string>

--- a/res/values-ja-rJP/cr_strings.xml
+++ b/res/values-ja-rJP/cr_strings.xml
@@ -1561,7 +1561,7 @@
     <string name="media_scanner_on_boot_disabled">メディアをスキャンしない</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">設定をリセット</string>
-    <string name="reset_settings_message">現在のユーザーのほとんどの crDroid 設定を初期設定に戻します。続行しますか？</string>
+    <string name="reset_settings_message">現在のユーザーのほとんどの FlokoROM 設定を初期設定に戻します。続行しますか？</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">アップデート</string>
     <string name="ota_crdroid_summary">OTA アップデートの有無とお使いの端末向けのリンクをチェックします</string>

--- a/res/values-ko-rKR/cr_strings.xml
+++ b/res/values-ko-rKR/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">미디어 스캔하지 않음</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">설정 초기화</string>
-    <string name="reset_settings_message">대부분의 crdroid 설정이 현재 사용자의 기본값으로 재설정됩니다. 계속 하시겠습니까?</string>
+    <string name="reset_settings_message">대부분의 FlokoROM 설정이 현재 사용자의 기본값으로 재설정됩니다. 계속 하시겠습니까?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">업데이트</string>
     <string name="ota_crdroid_summary">장치에 OTA 업데이트를 확인합니다</string>

--- a/res/values-ms-rMY/cr_strings.xml
+++ b/res/values-ms-rMY/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Check for OTA update and links for your device</string>

--- a/res/values-nl-rNL/cr_strings.xml
+++ b/res/values-nl-rNL/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Media niet scannen</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Instellingen resetten</string>
-    <string name="reset_settings_message">Dit zal de meeste crdroid instellingen terugzetten op de standaardwaarden voor de huidige gebruiker. Wilt u doorgaan?</string>
+    <string name="reset_settings_message">Dit zal de meeste FlokoROM instellingen terugzetten op de standaardwaarden voor de huidige gebruiker. Wilt u doorgaan?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Bijwerken</string>
     <string name="ota_crdroid_summary">Selectievakje voor OTA update en links voor uw apparaat</string>

--- a/res/values-pl-rPL/cr_strings.xml
+++ b/res/values-pl-rPL/cr_strings.xml
@@ -1555,7 +1555,7 @@ https://plus.google.com/communities/118297646046960923906</string>
     <string name="media_scanner_on_boot_disabled">Nie skanuj mediów</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Resetuj ustawienia</string>
-    <string name="reset_settings_message">To spowoduje zresetowanie większości ustawień crDroid do wartości domyślnych dla bieżącego użytkownika. Czy chcesz kontynuować?</string>
+    <string name="reset_settings_message">To spowoduje zresetowanie większości ustawień FlokoROM do wartości domyślnych dla bieżącego użytkownika. Czy chcesz kontynuować?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Aktualizacje</string>
     <string name="ota_crdroid_summary">Sprawdzenie dla aplikacji OTA oraz linków dla twojego urządzenia</string>

--- a/res/values-pt-rBR/cr_strings.xml
+++ b/res/values-pt-rBR/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Não escanear mídia</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Redefinir configurações</string>
-    <string name="reset_settings_message">Isso redefinirá a maioria da configurações crdroid para seus valores padrões para o usuário atual. Gostaria de continuar?</string>
+    <string name="reset_settings_message">Isso redefinirá a maioria da configurações FlokoROM para seus valores padrões para o usuário atual. Gostaria de continuar?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Atualizações</string>
     <string name="ota_crdroid_summary">Verifique a atualização OTA e os links para o seu dispositivo</string>

--- a/res/values-pt-rPT/cr_strings.xml
+++ b/res/values-pt-rPT/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Não escanear mídia</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Redefinir configurações</string>
-    <string name="reset_settings_message">Isso irá redefinir a maioria das configurações do crdroid para seus valores padrão para o usuário atual. Você gostaria de continuar?</string>
+    <string name="reset_settings_message">Isso irá redefinir a maioria das configurações do FlokoROM para seus valores padrão para o usuário atual. Você gostaria de continuar?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Atualizações</string>
     <string name="ota_crdroid_summary">Verifique a atualização OTA e os links para o seu dispositivo</string>

--- a/res/values-ro-rRO/cr_strings.xml
+++ b/res/values-ro-rRO/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Nu se scanează media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reinițializarea setărilor</string>
-    <string name="reset_settings_message">Aceasta actiune v-a reseta setariile crDroid la valorile implicite. Doresti sa continui?</string>
+    <string name="reset_settings_message">Aceasta actiune v-a reseta setariile FlokoROM la valorile implicite. Doresti sa continui?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Actualizări\"</string>
     <string name="ota_crdroid_summary">Verificare actualizari pentru dispozitivul dumneavoastra</string>

--- a/res/values-ru-rRU/cr_strings.xml
+++ b/res/values-ru-rRU/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Не сканировать медиа</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Сбросить настройки</string>
-    <string name="reset_settings_message">Это приведет к сбросу большинства настроек crdroid к значениям по умолчанию для текущего пользователя. Продолжить?</string>
+    <string name="reset_settings_message">Это приведет к сбросу большинства настроек FlokoROM к значениям по умолчанию для текущего пользователя. Продолжить?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Обновления</string>
     <string name="ota_crdroid_summary">Проверить OTA обновление и ссылки для вашего устройства</string>

--- a/res/values-sk-rSK/cr_strings.xml
+++ b/res/values-sk-rSK/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Neskenovať médiá</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Resetovať nastavenia</string>
-    <string name="reset_settings_message">To obnoví väčšinu crdroid nastavení na predvolené hodnoty pre aktuálneho používateľa. Chcete pokračovať?</string>
+    <string name="reset_settings_message">To obnoví väčšinu FlokoROM nastavení na predvolené hodnoty pre aktuálneho používateľa. Chcete pokračovať?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Aktualizácie</string>
     <string name="ota_crdroid_summary">Skontrovat aktualizáciu OTA a odkazy pre zariadenie</string>

--- a/res/values-sl-rSI/cr_strings.xml
+++ b/res/values-sl-rSI/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Check for OTA update and links for your device</string>

--- a/res/values-sv-rSE/cr_strings.xml
+++ b/res/values-sv-rSE/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Kontrollera för OTA uppdatering och länkar för din enhet</string>

--- a/res/values-ta-rIN/cr_strings.xml
+++ b/res/values-ta-rIN/cr_strings.xml
@@ -1561,7 +1561,7 @@ fling_left_up_swipe
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Check for OTA update and links for your device</string>

--- a/res/values-tr-rTR/cr_strings.xml
+++ b/res/values-tr-rTR/cr_strings.xml
@@ -1556,7 +1556,7 @@ Sadece yarı şeffaf bildirimler etkin.</string>
     <string name="media_scanner_on_boot_disabled">Medyayı tarama</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Ayarları sıfırla</string>
-    <string name="reset_settings_message">Bu mevcut kullanıcı için çoğu crdroid ayarlarını varsayılan değerlerine sıfırlar. Devam etmek ister misin?</string>
+    <string name="reset_settings_message">Bu mevcut kullanıcı için çoğu FlokoROM ayarlarını varsayılan değerlerine sıfırlar. Devam etmek ister misin?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Güncellemeler</string>
     <string name="ota_crdroid_summary">crDroid güncellemelerini kontrol et</string>

--- a/res/values-uk-rUA/cr_strings.xml
+++ b/res/values-uk-rUA/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Не сканувати медіа</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Скинути налаштування</string>
-    <string name="reset_settings_message">Буде здійснено скидання більшості параметрів crdroid до їх значень за замовчуванням для поточного користувача. Чи хотіли б Ви продовжити?</string>
+    <string name="reset_settings_message">Буде здійснено скидання більшості параметрів FlokoROM до їх значень за замовчуванням для поточного користувача. Чи хотіли б Ви продовжити?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Оновлення</string>
     <string name="ota_crdroid_summary">Перевірити оновлення ota і однієї для вашого пристрою</string>

--- a/res/values-ur-rPK/cr_strings.xml
+++ b/res/values-ur-rPK/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Do not scan media</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Reset settings</string>
-    <string name="reset_settings_message">This will reset most crdroid settings to their default values for the current user. Would you like to continue?</string>
+    <string name="reset_settings_message">This will reset most FlokoROM settings to their default values for the current user. Would you like to continue?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Updates</string>
     <string name="ota_crdroid_summary">Check for OTA update and links for your device</string>

--- a/res/values-vi-rVN/cr_strings.xml
+++ b/res/values-vi-rVN/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">Không quét đa phương tiện</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">Đặt lại cài đặt</string>
-    <string name="reset_settings_message">Điều này sẽ đặt lại hầu hết crdroid thiết lập các giá trị mặc định cho người dùng hiện tại. Bạn có muốn tiếp tục không?</string>
+    <string name="reset_settings_message">Điều này sẽ đặt lại hầu hết FlokoROM thiết lập các giá trị mặc định cho người dùng hiện tại. Bạn có muốn tiếp tục không?</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">Cập Nhật</string>
     <string name="ota_crdroid_summary">Kiểm tra cập nhật OTA và liên kết cho thiết bị của bạn</string>

--- a/res/values-zh-rCN/cr_strings.xml
+++ b/res/values-zh-rCN/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">不扫描媒体</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">重置设置</string>
-    <string name="reset_settings_message">这将把大多数 crdroid 设置重置为当前用户的默认值。您要继续吗？</string>
+    <string name="reset_settings_message">这将把大多数 FlokoROM 设置重置为当前用户的默认值。您要继续吗？</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">更新</string>
     <string name="ota_crdroid_summary">检查您的设备的 OTA 更新和链接</string>

--- a/res/values-zh-rTW/cr_strings.xml
+++ b/res/values-zh-rTW/cr_strings.xml
@@ -1554,7 +1554,7 @@
     <string name="media_scanner_on_boot_disabled">不掃描媒體</string>
     <!-- Reset settings -->
     <string name="reset_settings_title">重設設定</string>
-    <string name="reset_settings_message">這將把大多數 crDroid 設置重置為當前使用者的預設值。您要繼續嗎？</string>
+    <string name="reset_settings_message">這將把大多數 FlokoROM 設置重置為當前使用者的預設值。您要繼續嗎？</string>
     <!-- OTA -->
     <string name="ota_crdroid_title">更新</string>
     <string name="ota_crdroid_summary">檢查您的設備的 OTA 更新和連結</string>


### PR DESCRIPTION
reset_settings_messageのstringのcrDroidからFlokoROMに置換しました。
言語によってcrdroidだったりcrDroidだったりしましたが、reset_settings_messageでサーチかけたので多分全部置き換えたはずです。