### PR TITLE
[2/2] Floko: Add back transparency

### DIFF
--- a/res/xml/crdroid_settings_ui.xml
+++ b/res/xml/crdroid_settings_ui.xml
@@ -101,14 +101,14 @@
         android:summary="@string/style_summary"
         android:fragment="com.crdroid.settings.fragments.ui.ThemeSettings" />
 
-    <!--<Preference
-        android:key="trans_porn"
+    <Preference
+        android:key="trans_fragment"
         android:icon="@drawable/ic_transparency"
         android:title="@string/trans"
         android:summary="@string/trans_summary"
-        android:fragment="com.crdroid.settings.fragments.TransparencyPornFragment" />
+        android:fragment="com.crdroid.settings.fragments.ui.TransparencyFragment" />
 
-    <com.crdroid.settings.preferences.SystemSettingSwitchPreference
+    <!--<com.crdroid.settings.preferences.SystemSettingSwitchPreference
         android:key="show_alarm_fullscreen"
         android:icon="@drawable/ic_alarm_check"
         android:title="@string/show_alarm_fullscreen_title"

--- a/res/xml/transparency_layout.xml
+++ b/res/xml/transparency_layout.xml
@@ -3,9 +3,9 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
 
-    <PreferenceCategory
+    <!--<PreferenceCategory
         android:title="@string/trans_qs">
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="qs_transparent_shade"
             android:title="@string/qs_transparent_shade"
             android:max="255"
@@ -21,11 +21,11 @@
             android:entryValues="@array/qs_stroke_values"
             android:defaultValue="0" />
 
-        <com.crdroid.settings.preferences.ColorPickerPreference
+        <com.crdroid.settings.preferences.colorpicker.ColorPickerPreference
             android:key="qs_stroke_color"
             android:title="@string/qs_stroke_color_title" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="qs_stroke_thickness"
             android:title="@string/qs_stroke_thickness_title"
             android:max="25"
@@ -33,7 +33,7 @@
             settings:units="px"
             android:persistent="false" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="qs_corner_radius"
             android:title="@string/qs_corner_radius_title"
             android:max="50"
@@ -41,7 +41,7 @@
             settings:units="px"
             android:persistent="false" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="qs_dash_width"
             android:title="@string/qs_dash_width_title"
             android:max="50"
@@ -49,26 +49,26 @@
             settings:units="px"
             android:persistent="false" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="qs_dash_gap"
             android:title="@string/qs_dash_gap_title"
             android:max="50"
             settings:min="1"
             settings:units="px"
             android:persistent="false" />
-   </PreferenceCategory>
+   </PreferenceCategory>-->
 
    <PreferenceCategory
         android:title="@string/trans_vol_dialog">
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="transparent_volume_dialog"
             android:title="@string/volume_dialog_transparency"
-            android:max="255"
-            settings:min="0"
-            settings:units=""
+            android:max="100"
+            settings:min="1"
+            settings:units="%"
             android:persistent="false" />
 
-        <ListPreference
+        <!--<ListPreference
             android:key="volume_dialog_stroke"
             android:title="@string/volume_dialog_stroke_title"
             android:dialogTitle="@string/volume_dialog_stroke_title"
@@ -76,12 +76,12 @@
             android:entryValues="@array/volume_dialog_stroke_values"
             android:defaultValue="0" />
 
-        <com.crdroid.settings.preferences.ColorPickerPreference
+        <com.crdroid.settings.preferences.colorpicker.ColorPickerPreference
             android:key="volume_dialog_stroke_color"
             android:title="@string/volume_dialog_stroke_color_title"
             android:defaultValue="0xffffffff" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="volume_dialog_stroke_thickness"
             android:title="@string/volume_dialog_stroke_thickness_title"
             android:max="25"
@@ -89,7 +89,7 @@
             settings:units="px"
             android:persistent="false" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="volume_dialog_corner_radius"
             android:title="@string/volume_dialog_corner_radius_title"
             android:max="50"
@@ -97,7 +97,7 @@
             settings:units="px"
             android:persistent="false" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="volume_dialog_dash_width"
             android:title="@string/volume_dialog_dash_width_title"
             android:max="50"
@@ -105,31 +105,31 @@
             settings:units="px"
             android:persistent="false" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="volume_dialog_dash_gap"
             android:title="@string/volume_dialog_dash_gap_title"
             android:max="50"
             settings:min="1"
             settings:units="px"
-            android:persistent="false" />
+            android:persistent="false" />-->
     </PreferenceCategory>
 
     <PreferenceCategory
         android:title="@string/trans_power_menu">
-        <com.crdroid.settings.preferences.SeekBarPreference
-            android:key="transparent_power_menu"
+        <com.crdroid.settings.preferences.CustomSeekBarPreference
+            android:key="transparent_actions_dialog"
             android:title="@string/power_menu_transparency"
             android:max="100"
-            settings:min="0"
+            settings:min="1"
             settings:units="%"
             android:persistent="false" />
 
-        <com.crdroid.settings.preferences.SeekBarPreference
+        <!--<com.crdroid.settings.preferences.CustomSeekBarPreference
             android:key="transparent_power_dialog_dim"
             android:title="@string/power_menu_dialog_dim"
             android:max="100"
             settings:min="0"
             settings:units="%"
-            android:persistent="false" />
+            android:persistent="false" />-->
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/com/crdroid/settings/fragments/UserInterface.java
+++ b/src/com/crdroid/settings/fragments/UserInterface.java
@@ -49,6 +49,7 @@ import com.crdroid.settings.fragments.ui.DozeSettings;
 import com.crdroid.settings.fragments.ui.RoundedCorners;
 import com.crdroid.settings.fragments.ui.SmartPixels;
 import com.crdroid.settings.fragments.ui.ThemeSettings;
+import com.crdroid.settings.fragments.ui.TransparencyFragment;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -93,6 +94,7 @@ public class UserInterface extends SettingsPreferenceFragment implements Indexab
         RoundedCorners.reset(mContext);
         SmartPixels.reset(mContext);
         ThemeSettings.reset(mContext);
+        TransparencyFragment.reset(mContext);
     }
 
     @Override

--- a/src/com/crdroid/settings/fragments/ui/TransparencyFragment.java
+++ b/src/com/crdroid/settings/fragments/ui/TransparencyFragment.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2016-2019 crDroid Android Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.crdroid.settings.fragments.ui;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.ContentResolver;
+import android.content.res.Resources;
+import android.database.ContentObserver;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.UserHandle;
+import androidx.preference.ListPreference;
+import androidx.preference.Preference;
+import androidx.preference.Preference.OnPreferenceChangeListener;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
+import android.provider.Settings;
+import android.widget.Toast;
+
+import com.android.settings.R;
+import com.android.settings.SettingsPreferenceFragment;
+
+import com.crdroid.settings.preferences.CustomSeekBarPreference;
+import com.crdroid.settings.preferences.colorpicker.ColorPickerPreference;
+
+import com.android.internal.logging.nano.MetricsProto;
+
+public class TransparencyFragment extends SettingsPreferenceFragment
+        implements Preference.OnPreferenceChangeListener {
+
+    private static final String PREF_TRANSPARENT_VOLUME_DIALOG = "transparent_volume_dialog";
+    private static final String PREF_TRANSPARENT_ACTIONS_DIALOG = "transparent_actions_dialog";
+
+    private CustomSeekBarPreference mVolumeDialogAlpha;
+    private CustomSeekBarPreference mActionsDialogAlpha;
+
+    @Override
+    public int getMetricsCategory() {
+        return MetricsProto.MetricsEvent.CRDROID_SETTINGS;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.transparency_layout);
+
+        PreferenceScreen prefSet = getPreferenceScreen();
+        final ContentResolver resolver = getActivity().getContentResolver();
+
+        // Volume dialog alpha
+        mVolumeDialogAlpha =
+                (CustomSeekBarPreference) findPreference(PREF_TRANSPARENT_VOLUME_DIALOG);
+        int volumeDialogAlpha = Settings.System.getInt(resolver,
+                Settings.System.TRANSPARENT_VOLUME_DIALOG, 100);
+        mVolumeDialogAlpha.setValue(volumeDialogAlpha / 1);
+        mVolumeDialogAlpha.setOnPreferenceChangeListener(this);
+
+        // Power menu alpha
+        mActionsDialogAlpha =
+                (CustomSeekBarPreference) findPreference(PREF_TRANSPARENT_ACTIONS_DIALOG);
+        int actionsDialogAlpha = Settings.System.getInt(resolver,
+                Settings.System.TRANSPARENT_ACTIONS_DIALOG, 100);
+        mActionsDialogAlpha.setValue(actionsDialogAlpha / 1);
+        mActionsDialogAlpha.setOnPreferenceChangeListener(this);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        ContentResolver resolver = getActivity().getContentResolver();
+        if (preference == mVolumeDialogAlpha) {
+            int alpha = (Integer) newValue;
+            Settings.System.putInt(resolver,
+                    Settings.System.TRANSPARENT_VOLUME_DIALOG, alpha * 1);
+            return true;
+        } else if (preference == mActionsDialogAlpha) {
+            int alpha = (Integer) newValue;
+            Settings.System.putInt(resolver,
+                    Settings.System.TRANSPARENT_ACTIONS_DIALOG, alpha * 1);
+            return true;
+        }
+        return false;
+    }
+
+    public static void reset(Context mContext) {
+        ContentResolver resolver = mContext.getContentResolver();
+        Settings.System.putIntForUser(resolver,
+                Settings.System.TRANSPARENT_VOLUME_DIALOG, 100, UserHandle.USER_CURRENT);
+        Settings.System.putIntForUser(resolver,
+                Settings.System.TRANSPARENT_ACTIONS_DIALOG, 100, UserHandle.USER_CURRENT);
+    }
+}


### PR DESCRIPTION
過去の遺産 (Nougat時代) を生かして
Floko Settings -> 透明度
の下にメニューをつくってあるけど、

ボタン→電源メニュー→透明度の設定
サウンド→音量パネル→透明度の設定

とかにしたほうがいいような気がしなくもない