### PR TITLE
Floko: OmniSwitch Recent improvements

### DIFF
--- a/res/values-ja-rJP/cr_strings.xml
+++ b/res/values-ja-rJP/cr_strings.xml
@@ -118,6 +118,8 @@
     <string name="omniswitch_start_settings_summary">OmniSwitch の設定を開きます</string>
     <string name="omniswitch_first_time_title">OmniSwitch</string>
     <string name="omniswitch_first_time_message">OmniSwitch の設定を開いて、OmniSwitch を有効化していることを確認してください。</string>
+    <string name="recents_information">アプリ履歴について</string>
+    <string name="recents_information_summary">3 ボタンナビゲーションのときのアプリ履歴表示を変更できます</string>
     <!-- Lockscreen categories -->
     <string name="lockscreen_shortcuts_category">ショートカット</string>
     <string name="lockscreen_interface_category">インターフェース</string>

--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -2087,6 +2087,8 @@
     <string name="recents_style_aosp">AOSP</string>
     <string name="recents_style_omni">OmniSwitch</string>
     <string name="device_restart_required">Restart your device to apply changes</string>
+    <string name="recents_information">Abour recents style</string>
+    <string name="recents_information_summary">Customize the recents style when 3-button navigation</string>
 
     <!-- Custom seekbar -->
     <string name="custom_seekbar_value">Value: <xliff:g id="v">%s</xliff:g></string>

--- a/res/xml/crdroid_settings_recents.xml
+++ b/res/xml/crdroid_settings_recents.xml
@@ -18,6 +18,11 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:settings="http://schemas.android.com/apk/res/com.android.settings">
 
+    <Preference
+        android:key="recents_info"
+        android:title="@string/recents_information"
+        android:summary="@string/recents_information_summary" />
+
     <com.crdroid.settings.preferences.SystemSettingListPreference
         android:key="recents_component"
         android:icon="@drawable/ic_recents"
@@ -33,11 +38,11 @@
         android:title="@string/recents_icon_pack_title"
         android:summary="@string/recents_icon_pack_summary" />
 
-    <PreferenceCategory 
+    <!--PreferenceCategory
         android:key="stock_recents"
         android:title="@string/recents_default_category">
 
-        <!--<ListPreference
+        <ListPreference
             android:key="immersive_recents"
             android:icon="@drawable/ic_recents"
             android:title="@string/immersive_recents_title"
@@ -55,7 +60,7 @@
             <intent android:action="android.intent.action.MAIN"
                 android:targetPackage="com.android.settings"
                 android:targetClass="com.crdroid.settings.fragments.HAFRAppListActivity" />
-        </PreferenceScreen>-->
+        </PreferenceScreen>
 
         <com.crdroid.settings.preferences.SystemSettingSwitchPreference
             android:key="systemui_recents_mem_display"
@@ -64,7 +69,7 @@
             android:summary="@string/systemui_recents_mem_display_summary"
             android:defaultValue="false" />
 
-        <!--<com.crdroid.settings.preferences.ColorPickerPreference
+        <com.crdroid.settings.preferences.ColorPickerPreference
             android:key="systemui_recents_mem_barcolor"
             android:icon="@drawable/ic_memory"
             android:title="@string/systemui_recents_mem_display_color"
@@ -78,7 +83,7 @@
             android:title="@string/systemui_recents_mem_display_text_color"
             android:defaultValue="#00ffffff"
             android:dependency="systemui_recents_mem_display"
-            alphaSlider="true" />-->
+            alphaSlider="true" />
 
         <com.crdroid.settings.preferences.SystemSettingSwitchPreference
             android:key="show_clear_all_recents"
@@ -96,7 +101,7 @@
             android:defaultValue="3"
             android:dependency="show_clear_all_recents" />
 
-        <!--<com.crdroid.settings.preferences.SystemSettingSwitchPreference
+        <com.crdroid.settings.preferences.SystemSettingSwitchPreference
             android:key="recents_dismiss_icon"
             android:icon="@drawable/ic_dismiss"
             android:title="@string/recents_dismiss_icon_title"
@@ -122,10 +127,10 @@
             android:key="recents_use_grid"
             android:icon="@drawable/ic_grid_view"
             android:title="@string/recents_use_grid_title"
-            android:summary="@string/recents_use_grid_summary" />-->
+            android:summary="@string/recents_use_grid_summary" />
     </PreferenceCategory>
 
-    <!--<PreferenceCategory 
+    <PreferenceCategory
         android:title="@string/recents_omni_category">
 
         <SwitchPreference
@@ -180,4 +185,5 @@
                 android:targetClass="org.omnirom.omniswitch.SettingsActivity" />
         </Preference>
     </PreferenceCategory>
+
 </PreferenceScreen>

--- a/src/com/crdroid/settings/fragments/Recents.java
+++ b/src/com/crdroid/settings/fragments/Recents.java
@@ -71,6 +71,7 @@ public class Recents extends SettingsPreferenceFragment
 
     public static final String TAG = "Recents";
 
+    private static final String PREF_RECENTS_INFO = "recents_info";
     private static final String PREF_RECENTS_STYLE = "recents_component";
     private static final String PREF_RECENTS_ICONPACK = "recents_icon_pack";
     private static final String CATEGORY_STOCK = "stock_recents";
@@ -91,6 +92,8 @@ public class Recents extends SettingsPreferenceFragment
     private ListView mListView;
 
     private ListPreference mRecentsStyle;
+    private Preference mRecentsInfo;
+    private Preference mIconSettings;
     private Preference mStockSettings;
     private Preference mOmniSettings;
 
@@ -102,41 +105,64 @@ public class Recents extends SettingsPreferenceFragment
 
         final PreferenceScreen prefScreen = getPreferenceScreen();
 
-        mRecentsStyle = (ListPreference) findPreference(PREF_RECENTS_STYLE);
-        mRecentsStyle.setOnPreferenceChangeListener(this);
+        int navbarMode = Settings.Secure.getIntForUser(getContentResolver(),
+                Settings.Secure.NAVIGATION_MODE, 3, UserHandle.USER_CURRENT);
 
         int recentsStyle = Settings.System.getIntForUser(getContentResolver(),
                 Settings.System.RECENTS_COMPONENT, 0, UserHandle.USER_CURRENT);
 
-        mStockSettings = (PreferenceCategory) findPreference(CATEGORY_STOCK);
+        mRecentsInfo = (Preference) findPreference(PREF_RECENTS_INFO);
+        mRecentsStyle = (ListPreference) findPreference(PREF_RECENTS_STYLE);
+        mRecentsStyle.setOnPreferenceChangeListener(this);
+        mIconSettings = (Preference) findPreference(PREF_RECENTS_ICONPACK);
+        //mStockSettings = (PreferenceCategory) findPreference(CATEGORY_STOCK);
         mOmniSettings = (PreferenceCategory) findPreference(CATEGORY_OMNI);
 
-        switch (recentsStyle) {
-            case 0:
-                mStockSettings.setEnabled(false);
-                mStockSettings.setSelectable(false);
-                mOmniSettings.setEnabled(false);
-                mOmniSettings.setSelectable(false);
-                break;
-            case 1:
-                mStockSettings.setEnabled(true);
-                mStockSettings.setSelectable(true);
-                mOmniSettings.setEnabled(false);
-                mOmniSettings.setSelectable(false);
-                break;
-            case 2:
-                boolean SwitchRunning = OmniSwitchConstants.isOmniSwitchRunning(getContext());
-                if (!SwitchRunning) {
-                    Toast.makeText(getActivity(), R.string.omniswitch_first_time_message,
-                        Toast.LENGTH_LONG).show();
-                    Settings.System.putInt(getContentResolver(),
-                        Settings.System.RECENTS_OMNI_SWITCH_ENABLED, 0);
-                }
-                mStockSettings.setEnabled(false);
-                mStockSettings.setSelectable(false);
-                mOmniSettings.setEnabled(true);
-                mOmniSettings.setSelectable(true);
-                break;
+        mRecentsInfo.setEnabled(true);
+
+        if (navbarMode == 0) {
+            mRecentsStyle.setEnabled(true);
+            mRecentsStyle.setSelectable(true);
+            mIconSettings.setEnabled(true);
+            mIconSettings.setSelectable(true);
+
+            switch (recentsStyle) {
+                case 0:
+                    //mStockSettings.setEnabled(false);
+                    //mStockSettings.setSelectable(false);
+                    mOmniSettings.setEnabled(false);
+                    mOmniSettings.setSelectable(false);
+                    break;
+                case 1:
+                    //mStockSettings.setEnabled(true);
+                    //mStockSettings.setSelectable(true);
+                    mOmniSettings.setEnabled(false);
+                    mOmniSettings.setSelectable(false);
+                    break;
+                case 2:
+                    boolean SwitchRunning = OmniSwitchConstants.isOmniSwitchRunning(getContext());
+                    if (!SwitchRunning) {
+                        Toast.makeText(getActivity(), R.string.omniswitch_first_time_message,
+                            Toast.LENGTH_LONG).show();
+                        Settings.System.putInt(getContentResolver(),
+                            Settings.System.RECENTS_OMNI_SWITCH_ENABLED, 0);
+                    }
+                    //mStockSettings.setEnabled(false);
+                    //mStockSettings.setSelectable(false);
+                    mOmniSettings.setEnabled(true);
+                    mOmniSettings.setSelectable(true);
+                    break;
+                default:
+            }
+        } else {
+            mRecentsStyle.setEnabled(false);
+            mRecentsStyle.setSelectable(false);
+            mIconSettings.setEnabled(false);
+            mIconSettings.setSelectable(false);
+            //mStockSettings.setEnabled(false);
+            //mStockSettings.setSelectable(false);
+            mOmniSettings.setEnabled(false);
+            mOmniSettings.setSelectable(false);
         }
     }
 
@@ -153,22 +179,22 @@ public class Recents extends SettingsPreferenceFragment
     private void updateRecentStyleSettings(int recentsStyle) {
         switch (recentsStyle) {
             case 0:
-                mStockSettings.setEnabled(false);
-                mStockSettings.setSelectable(false);
+                //mStockSettings.setEnabled(false);
+                //mStockSettings.setSelectable(false);
                 mOmniSettings.setEnabled(false);
                 mOmniSettings.setSelectable(false);
                 Settings.System.putInt(getContentResolver(),
                     Settings.System.RECENTS_OMNI_SWITCH_ENABLED, 0);
-                Toast.makeText(getActivity(), R.string.device_restart_required, Toast.LENGTH_SHORT).show();
+                //Toast.makeText(getActivity(), R.string.device_restart_required, Toast.LENGTH_SHORT).show();
                 break;
             case 1:
-                mStockSettings.setEnabled(true);
-                mStockSettings.setSelectable(true);
+                //mStockSettings.setEnabled(true);
+                //mStockSettings.setSelectable(true);
                 mOmniSettings.setEnabled(false);
                 mOmniSettings.setSelectable(false);
                 Settings.System.putInt(getContentResolver(),
                     Settings.System.RECENTS_OMNI_SWITCH_ENABLED, 0);
-                Toast.makeText(getActivity(), R.string.device_restart_required, Toast.LENGTH_SHORT).show();
+                //Toast.makeText(getActivity(), R.string.device_restart_required, Toast.LENGTH_SHORT).show();
                 break;
             case 2:
                 boolean SwitchRunning = OmniSwitchConstants.isOmniSwitchRunning(getContext());
@@ -177,8 +203,8 @@ public class Recents extends SettingsPreferenceFragment
                         Toast.LENGTH_LONG).show();
                     startActivity(OmniSwitchConstants.INTENT_LAUNCH_APP);
                 }
-                mStockSettings.setEnabled(false);
-                mStockSettings.setSelectable(false);
+                //mStockSettings.setEnabled(false);
+                //mStockSettings.setSelectable(false);
                 mOmniSettings.setEnabled(true);
                 mOmniSettings.setSelectable(true);
                 Settings.System.putInt(getContentResolver(),


### PR DESCRIPTION
* Add information for recents setting.
  We can only customize if 3-button navigation.
* Comment out AOSP recents category.
  (AOSP recent needs SystemUIWithLegacyRecents)
* Remove unnecessary restart toast.

Signed-off-by: koron393 <koron393@gmail.com>
Change-Id: I4ecb03f08a05dc0ae6777aa3c84b98462bcc64d4

![Screenshot_20200406-045440_](https://user-images.githubusercontent.com/2731050/78508945-89a86a80-77c5-11ea-8314-067064537581.png)
